### PR TITLE
fix #1 unit test failure after sensor was disabled

### DIFF
--- a/test/unit_test_001.cpp
+++ b/test/unit_test_001.cpp
@@ -87,7 +87,9 @@ unittest(test_getUV)
 
   assertEqualFloat(0, light.getUV(), 0.0001);
   assertEqualFloat(0, light.getUV(LOW), 0.0001);
-  // assertEqualFloat(0, light.getUV(HIGH), 0.0001);
+
+  light.enable();
+  assertEqualFloat(0, light.getUV(HIGH), 0.0001);
 
   for (float uv = 0; uv < 1; uv += 0.1)
   {


### PR DESCRIPTION
See issue #1 
Fix is enabling the sensor as the disabled one causes hanging unit test.