### PR TITLE
Update ML8511.cpp

### DIFF
--- a/.arduino-ci.yml
+++ b/.arduino-ci.yml
@@ -17,11 +17,11 @@ compile:
   # Choosing to run compilation tests on 2 different Arduino platforms
   platforms:
     - uno
-    # - due
-    # - zero
-    # - leonardo
+    - due
+    - zero
+    - leonardo
     - m4
     - esp32
-    # - esp8266
-    # - mega2560
+    - esp8266
+    - mega2560
     - rpipico

--- a/ML8511.cpp
+++ b/ML8511.cpp
@@ -49,6 +49,10 @@ float ML8511::getUV(uint8_t energyMode)
     uint32_t start = micros();
     while (micros() - start < 1000) yield();
   }
+  
+  // Override default bit resolution (Some higher end boards use 12bit, such as ESP32)
+  analogReadResolution(10); 
+  
   //  read the sensor
   float voltage = analogRead(_analogPin) * _voltsPerStep;
   //  go to low power mode?


### PR DESCRIPTION
Override default bit resolution (some boards may use a 12bit ADC) to use 10bit. 

While using 12bit by default and not overriden, division by 1023 exceeds the range 0~1.

:-)